### PR TITLE
Approved Constitutional Amendments 20230213

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -10,8 +10,15 @@
 \usepackage[utf8]{inputenc}
 
 % All items are numbered in dotted-decimal, starting with section number
-\setlist[enumerate]{label*=.\arabic*}
-\setlist[enumerate,1]{label=\thesection.\arabic*}
+\setlistdepth{9}
+\newlist{myEnumerate}{enumerate}{9}
+\setlist[myEnumerate]{label*=.\arabic*}
+\setlist[myEnumerate,1]{label=\thesection.\arabic*}
+
+\creflabelformat{myEnumeratei}{#2\textup{#1}#3}
+\crefname{myEnumeratei}{Item}{Items} % singular and plural forms of text labels
+\creflabelformat{myEnumerateii}{#2\textup{#1}#3}
+\crefname{myEnumerateii}{Item}{Items} % singular and plural forms of text labels
 
 % Make cross references bold and underlined
 \crefdefaultlabelformat{#2\textbf{\underline{#1}}#3}
@@ -26,13 +33,13 @@
 
 
 \section{Name} \label{sec:name}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The name of the Society shall be: Unigames.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Definitions} \label{sec:definitions}
-\begin{enumerate}
+\begin{myEnumerate}
     \item Guild - the University of Western Australia Student Guild.
     \item University - The University of Western Australia.
     \item Traditional games - games including, but are not necessarily limited to: pen and paper roleplaying games, live action roleplaying (LARP) games, wargames, choose your own adventure books, card games, and board games, but specifically excluding video games.
@@ -40,11 +47,11 @@
     \item The Society - Unigames.
     \item Fresher - First time member of Unigames, regardless of how many years they have been at university.
     \item Regulation - a rule, passed by Committee, with ongoing consequences to the Society. (For example a Regulation may be made that allows certain members to keep the clubroom open.)
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Objectives} \label{sec:objectives}
-\begin{enumerate}
+\begin{myEnumerate}
     \item To encourage and facilitate the playing, design and production of traditional games in all forms within University and more widely amongst the community.
     \item To remain affiliated to the Societies Council of the Guild
     \item To encourage and facilitate all forms of literature dealing with the topics of traditional games.
@@ -54,368 +61,378 @@
     \item To encourage and facilitate the holding of events and functions beneficial to Objectives of the Society.
     \item To encourage and promote cooperation between the Society and other societies and community-based organizations representative of the Society's interests.
     \item To ensure that the Society shall not by way of gift; transmit any monies, grants or property to any person except as detailed in \cref{sec:dissolution}.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Major Obligations to the Guild} \label{sec:obligations}
-\begin{enumerate}
+\begin{myEnumerate}
     \item Unigames shall comply with the rules of Guild and Societies Council, and all other provisions enrolled upon the Guild Statutes Book.
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item All Office Bearers shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
-          \end{enumerate}
+          \end{myEnumerate}
     \item Such rules supersede the Regulations of Unigames, and this Constitution, if and where contradiction occurs.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Membership of Unigames} \label{sec:membership}
-\begin{enumerate}
+\begin{myEnumerate}
     \item Unigames membership is targeted at, but not restricted to:
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item Students of the University
               \item Members of the Guild
               \item Past members of Unigames
-          \end{enumerate}
+          \end{myEnumerate}
     \item Membership
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item A Member is any person who is a Financial Member or an Honorary Life Member.
             \item The Committee may, by regulation, afford Members benefits that may not be extended to people who are not Members, such as discounts and library borrowing privileges.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item The Committee may temporarily restrict any benefits afforded to a Member as per \cref{sec:duties}
-            \end{enumerate}
-        \end{enumerate}
+            \end{myEnumerate}
+            \item All Members will be afforded the right to attend and speak at a General Meeting.
+              \begin{myEnumerate}
+                  \item The Committee may temporarily restrict this right afforded to a Member as per \cref{sec:duties} and the UWA Student Guild Standing Orders.
+              \end{myEnumerate}
+        \end{myEnumerate}
     \item Financial Membership
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item A Financial Member is any eligible person who has paid the membership fee and whose financial membership has not yet expired, or been terminated by other means.
-                \begin{enumerate}
+                \begin{myEnumerate}
                     \item Financial memberships shall expire 1 day prior to the Annual General Meeting held in the calendar year after the fee was paid.
                     \item The membership fee shall be set by the Committee, subject to the regulations set by the Guild.
                     \item An Excluded Person, as defined in \cref{sec:exclusion}, is not eligible to be a Financial Member.
                     \item A person may terminate their financial membership by means of resignation upon written request to the Secretary or President.
-                \end{enumerate}
-            \item Financial Members shall have the right to participate in a General Meeting as defined in \cref{sec:general_meetings} and \cref{sec:elections}
-        \end{enumerate}
+                    \item Each financial membership shall be either Ordinary or Associate
+                    \begin{myEnumerate}
+                      \item An Ordinary Financial Member is any person who is a current UWA Student at the time of purchase.
+                      \begin{myEnumerate}
+                          \item Ordinary Financial Members shall have the right to participate in a General Meeting as defined in \cref{sec:general_meetings} and \cref{sec:elections}.
+                      \end{myEnumerate}
+                      \item An Associate Financial Member is any person who is not a current UWA Student at the time of purchase.
+                  \end{myEnumerate}
+                \end{myEnumerate}
+        \end{myEnumerate}
     \item Honorary Life Membership
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item An Honorary Life Member is any eligible person who has received an honorary life membership which has not been terminated.
-                \begin{enumerate}
+                \begin{myEnumerate}
                     \item Honorary life membership may be conferred by a two-thirds majority of a General Meeting upon any eligible person who has performed outstanding service to Unigames.
                     \item In exceptional circumstances, an honorary life membership may be removed by a two-thirds majority of a General Meeting.
                     \item An honorary life member may resign their honorary life membership upon written request to the Secretary or President.
                     \item An Excluded Person, as defined in \cref{sec:exclusion}, is not eligible to be an Honorary Life Member.
-                \end{enumerate}
-          \end{enumerate}
-\end{enumerate}
+                \end{myEnumerate}
+          \end{myEnumerate}
+\end{myEnumerate}
 
 
 \section{The Committee} \label{sec:committee}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The Committee shall consist of the following Committee Members:
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item The Executive Office Bearers:
-                \begin{enumerate}
+                \begin{myEnumerate}
                     \item The President;
                     \item The Vice President;
                     \item The Treasurer;
                     \item The Secretary; and
                     \item The Librarian;
-                \end{enumerate}
+                \end{myEnumerate}
             \item The Fresher Representative; and
             \item Four Ordinary Committee Members.
-        \end{enumerate}
+        \end{myEnumerate}
     \item Committee members are subject to the following eligibility criteria:
-        \begin{enumerate}
-            \item Each Committee Member must be a Financial Member for the duration of their term.
-            \item Each Executive Office Bearer must be a student of the University at the commencement of their term.
+        \begin{myEnumerate}
+            \item Each Committee Member must be an Ordinary Financial Member for the duration of their term.
             \item Each Executive Office Bearer must be a member of the Guild for the duration of their term.
             \item The Fresher Representative must be a Fresher at the commencement of their term.
-        \end{enumerate}
+        \end{myEnumerate}
     \item All Committee positions that are vacant during a General Meeting must be filled by election as defined \cref{sec:elections}
     \item Each Committee Member shall remain in office until: 
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item The first Annual General Meeting after they take office;
             \item They resign from their position by submitting written notice to the Secretary or President;
             \item They are elected or appointed to another Committee position; 
             \item They cease to be eligible for their position; or
             \item A General Meeting votes by two-thirds majority  to remove them from office.
-        \end{enumerate}
+        \end{myEnumerate}
     \item \label{item:exec_vacancy} If an Executive Office Bearer position is vacant outside of a General Meeting for any reason, the vacancy shall either:
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item Be filled through appointment of an existing Committee Member by Committee, subject to review at the next General Meeting.
-                \begin{enumerate}
+                \begin{myEnumerate}
                     \item When reviewing, a simple majority vote of the General Meeting will confirm the appointment. If such a vote fails, the position must be immediately filled by election (as per \cref{sec:elections}).
-                \end{enumerate}
+                \end{myEnumerate}
             \item Or it may remain vacant and be filled by election (as per \cref{sec:elections}) , at the next General Meeting, which must be held within the next 3 weeks.
-        \end{enumerate}
+        \end{myEnumerate}
     \item \label{item:ocm_vacancy} If an Ordinary Committee Member or Fresher Representative position is vacant outside of a General Meeting for any reason, the vacancy shall either:
-        \begin{enumerate}
-            \item Be filled through appointment of a Financial Member by Committee , subject to review at the next General Meeting
-                \begin{enumerate}
+        \begin{myEnumerate}
+            \item Be filled through appointment of an Ordinary Financial Member by Committee, subject to review at the next General Meeting.
+                \begin{myEnumerate}
                     \item When reviewing, a simple majority vote of the General Meeting will confirm the appointment. If such a vote fails then the position must be immediately filled by election (as per \cref{sec:elections}).
-                \end{enumerate}
+                \end{myEnumerate}
             \item Or it may remain vacant and be filled by election (as per \cref{sec:elections}), at the next General Meeting, which must be held within the next 3 weeks.
-        \end{enumerate}
+        \end{myEnumerate}
     \item The President may appoint their predecessor to the non-voting, advisory Committee position of Immediate Past President for the duration of their term.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{General Meetings} \label{sec:general_meetings}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The Committee must call at least one General Meeting of Unigames in each academic semester.
     \item No General Meeting may be held while a Guild General Meeting is in progress, provided this shall not apply where the written notice of the meeting was given before the written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of a disciplinary officer of the Guild.
     \item All General Meetings of Unigames shall be conducted in accordance with the procedures in the UWA Student Guild Standing Orders in all cases where they are applicable and not inconsistent with this Constitution or Regulations.
     \item The Secretary shall cause written notice of any General Meeting to be posted to Guild and Unigames notice boards and publications at least two weeks before the date appointed for that meeting.
     \item Motions to be considered at a General Meeting must be submitted to the Secretary in writing at least seven days before the date appointed for that meeting.
-        \begin{enumerate}
-            \item Only Financial Members may submit motions.
-        \end{enumerate}
+        \begin{myEnumerate}
+            \item Only Ordinary Financial Members may submit motions.
+        \end{myEnumerate}
     \item The Secretary shall make the agenda of any General Meeting accessible to all members at least four days before the date appointed for that meeting.
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item This agenda may be changed during the meeting, subject to the restriction in \cref{item:sgm_priority} if applicable.
-        \end{enumerate}
-    \item The quorum of a General Meeting shall consist of 21 Financial Members.
+        \end{myEnumerate}
+    \item The quorum of a General Meeting shall consist of 21 Ordinary Financial Members.
     \item The General Meeting shall, in addition to the powers expressly granted to it by this Constitution, have all powers which are granted to the Committee.
-    \item Only Financial Members may vote at General Meetings.
-        \begin{enumerate}
-            \item Financial Members who have held membership for at least 42 days prior to the General Meeting may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
-            \begin{enumerate}
+    \item Only Ordinary Financial Members may vote at General Meetings.
+        \begin{myEnumerate}
+            \item Ordinary Financial Members who have held membership for at least 42 days prior to the General Meeting may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
+            \begin{myEnumerate}
                 \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the meeting has been recorded.
                 \item The intent of the absentee votes must be clear and unambiguous to the Secretary or Officer.
-            \end{enumerate}
+            \end{myEnumerate}
             \item Absentee votes do not count as attendees for purposes of meeting quorum.
             \item Voting by means of a proxy is not allowed.
-        \end{enumerate}
+        \end{myEnumerate}
     \item \label{item:vacancies} Any Committee positions which are vacant during a general meeting must be filled by election at that meeting in accordance with \cref{sec:elections}
     \item The Committee may, at any time, call an Ordinary General Meeting of Unigames.
     \item The Committee must call an Annual General Meeting during the first four weeks of each University academic year.
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item Nominations for each Committee Position shall open two weeks prior to the Annual General Meeting. Nominations shall close at that meeting.
             \item All Committee positions shall be declared vacant during the meeting in accordance with \cref{sec:committee} and shall be filled by election as per \cref{item:vacancies}
-        \end{enumerate}
-    \item The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 Financial Members.
-        \begin{enumerate}
+        \end{myEnumerate}
+    \item The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 Ordinary Financial Members.
+        \begin{myEnumerate}
             \item Such a meeting shall be held no later than 15 business days immediately following receipt of such requisition.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so.
-            \end{enumerate}
+            \end{myEnumerate}
             \item \label{item:sgm_priority} Any business set out in the requisition shall have priority over all other business.
-        \end{enumerate}
-\end{enumerate}
+        \end{myEnumerate}
+\end{myEnumerate}
 
 
 \section{Election} \label{sec:elections}
-\begin{enumerate}
+\begin{myEnumerate}
     \item Elections may only be conducted by a General Meeting.
     \item Nominations for a Committee position shall be opened two weeks prior to the General Meeting, or as soon as practicable once a position has become vacant.
     \item Nominations shall be closed during the General Meeting.
     \item The General Meeting shall appoint two Returning Officers to conduct the election.
-    \begin{enumerate}
+    \begin{myEnumerate}
         \item To ensure impartiality, each Returning Officer:
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item Must not have been a Committee Member within the last 6 months;
             \item Must disclose any potential conflicts of interest prior to appointment; and
             \item Must not participate in the election outside their duties as a Returning Officer.
-        \end{enumerate}
-    \end{enumerate}
+        \end{myEnumerate}
+    \end{myEnumerate}
     \item The election of the offices and Committee shall be conducted by approval voting, i.e. each member may vote for any number of candidates.
-    \item Only Financial Members may nominate candidates, vote, or be nominated.
-        \begin{enumerate}
-            \item Financial Members who have held membership for at least 42 days prior to the election may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
-            \begin{enumerate}
+    \item Only Ordinary Financial Members may nominate candidates, vote, or be nominated.
+        \begin{myEnumerate}
+            \item Ordinary Financial Members who have held membership for at least 42 days prior to the election may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
+            \begin{myEnumerate}
                 \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the General Meeting has been recorded.
                 \item All absentee votes shall be given to the Returning Officers upon their appointment.
                 \item Absentee votes must be submitted in a form consistent with approval voting, and must be clear and unambiguous to the Returning Officers.
-            \end{enumerate}
+            \end{myEnumerate}
             \item Voting by means of a proxy is not allowed.
-        \end{enumerate}
-\end{enumerate}
+        \end{myEnumerate}
+\end{myEnumerate}
 
 
 \section{Duties and Powers} \label{sec:duties}
-\begin{enumerate}
+\begin{myEnumerate}
     \item Subject to this Constitution, the Committee shall be responsible for giving effect to the objectives of the Society (see \cref{sec:objectives}) and for carrying on its everyday business. The Committee shall have the following powers and duties, in addition to those elsewhere in the Constitution and in any Regulations:
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item To carry out the will of the Society.
             \item To create Regulations defining the rules and procedures of the Society.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item No regulation may contradict the Constitution.
-            \end{enumerate}
+            \end{myEnumerate}
             \item The Committee may, by Regulation, define roles to aid in the operations of the Society, such as supervision of the clubroom.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item The Committee shall have the power to appoint and remove specific Members to any roles.
                 \item The Committee cannot delegate greater powers than held by any individual Committee Member.
-            \end{enumerate}
+            \end{myEnumerate}
             \item \label{item:disciplinary_action} To enforce the rules and regulations of the Society and take disciplinary action where appropriate and proportional, including:
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item Restriction of Member benefits such as disallowing library usage;
                 \item Restriction of access to the Society’s physical spaces such as the clubroom or events;
                 \item Restriction of access to the Society’s digital spaces, such as social media groups;
                 \item Reporting misconduct to the Guild or University;
                 \item Imposition of fines;
                 \item Suspension or Expulsion as defined in \cref{sec:exclusion}.
-            \end{enumerate}
+            \end{myEnumerate}
             \item Acquire and dispose of property; to dispose of money; to open banking accounts; and to enter into contracts.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item The Committee shall not borrow money or incur debts or liabilities on behalf of or in the name of Unigames to a greater amount than five dollars for each and every existing financial member of the Society.
-            \end{enumerate}
-            \end{enumerate}
+            \end{myEnumerate}
+            \end{myEnumerate}
         \item Each Committee Member shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
-        \begin{enumerate}
+        \begin{myEnumerate}
             \item To act in the best interests of the Society.
             \item To enforce rules and regulations of the Society and take disciplinary action where appropriate as defined in \cref{item:disciplinary_action}.
-            \begin{enumerate}
+            \begin{myEnumerate}
                 \item Any action taken by a Committee Member may only endure until the next Committee Meeting, at which the Committee shall review any decision.
-            \end{enumerate}
-        \end{enumerate}
+            \end{myEnumerate}
+        \end{myEnumerate}
         \item \label{item:pres_duties} The President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item To coordinate and supervise the work of the Committee
                   \item To carry out the will of Unigames
                   \item To chair Committee and General Meetings of Unigames
                   \item When immediate action is required in any matter affecting the interests of the society:
-                        \begin{enumerate}
+                        \begin{myEnumerate}
                             \item To take such actions upon seeking the advice and agreement of another member of the Committee (preferably the Vice President).
                             \item Any actions taken as such, shall be subject to review at the next Committee meeting.
-                        \end{enumerate}
-              \end{enumerate}
+                        \end{myEnumerate}
+              \end{myEnumerate}
         \item The Vice President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item Assisting the President wherever possible.
                   \item Whenever the President is unavailable, to take on the duties and powers of the President as detailed in \cref{item:pres_duties}.
-              \end{enumerate}
+              \end{myEnumerate}
         \item The Treasurer shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item To keep proper books of account dealing with the property and finances of Unigames and to furnish the Committee with such information upon request.
                   \item To arrange and be responsible for the handling of the petty cash.
                   \item To prepare a financial statement detailing income and expenses during their term of office, for presentation at the Annual General Meeting.
                   \item To produce and deliver all necessary books, vouchers and other documents to the persons appointed by the Guild for the purpose of conducting an audit, insofar as such persons require.
                   \item To produce and deliver all necessary books, receipts and other documents to the persons appointed by the Guild for the purpose of obtaining grants, insofar as such persons require.
-              \end{enumerate}
+              \end{myEnumerate}
         \item The Secretary shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item To record and distribute all proceedings of Unigames in all meetings.
                   \item To provide the Guild with information about Unigames, upon request.
                   \item To keep record of all Society members, and their contact information.
                   \item To keep record of any members granted special powers, rights, or responsibilities by Committee.
                   \item To keep record of any Regulations passed by Committee.
-              \end{enumerate}
+              \end{myEnumerate}
         \item The Librarian shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item To maintain the library.
                   \item To maintain the catalogue and the borrowers records.
                   \item To research opportunities to expand the library, with respect to the desires of Society members.
                   \item To enforce Regulations regarding the library.
-              \end{enumerate}
+              \end{myEnumerate}
         \item The Fresher Representative shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
-              \begin{enumerate}
+              \begin{myEnumerate}
                   \item To look out for the needs, and rights of the Freshers.
                   \item To be aware of, and acquainted with all Freshers of the Society, insofar as is possible.
                   \item To be involved, insofar as is possible, in any Fresher targeted activity the Society may run.
-              \end{enumerate}
+              \end{myEnumerate}
         \item Should any Committee Member be temporarily unable to fulfill their duties, as defined above, another Committee Member may be appointed to temporarily take on some or all of their duties. (For example if the Secretary is uncontactable, another Committee Member may be appointed to call a Special General Meeting).
-    \end{enumerate}
+    \end{myEnumerate}
 
 
 \section{Committee Meetings} \label{sec:committee_meetings}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The Committee shall meet at such times and places as the President, in consultation with the other Committee members, shall determine.
     \item The Committee shall only exercise its powers (as defined in this constitution or in Regulations) at a properly convened meeting of the Committee, except as elsewhere provided in the Constitution.
     \item The Committee may conduct business by electronic circular, in the case of:
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item urgent business;
               \item business which because of its nature could not be set on the agenda;or
               \item business which by procedural motion, the Committee decided not to deal with at a Committee Meeting.
-          \end{enumerate}
+          \end{myEnumerate}
     \item The Secretary or President shall cause all members of the Committee to receive three days notice of any such meeting including a list of the business to be discussed. This list may be expanded upon during the meeting.
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item A meeting may be called without this notice, if eight or more, eligible to vote, Committee members are present, at least four of whom are executive office bearers.
-          \end{enumerate}
+          \end{myEnumerate}
     \item The Secretary shall forthwith call a Special Committee Meeting, upon receiving a written requisition from at least two Committee members.
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item Any such Special Meeting shall be held not later than seven days immediately following the receipt of such requisition.
-                    \begin{enumerate}
+                    \begin{myEnumerate}
                         \item If the Secretary fails to call the meeting within that time, anyone of the members signing the requisition may do so.
-                    \end{enumerate}
+                    \end{myEnumerate}
               \item Any business set out in the requisition shall have priority over all other business
-          \end{enumerate}
+          \end{myEnumerate}
     \item The quorum of a Committee meeting shall be six Committee members, who are eligible to vote, of which at least three must be executive office bearers.
     \item All meetings of the Committee shall be conducted in accordance with the procedures in the UWA Student Guild Standing Orders in all cases where they are applicable and not inconsistent with this Constitution or Regulations.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Deposits and Withdrawals of Monies} \label{sec:monies}
-\begin{enumerate}
+\begin{myEnumerate}
     \item All monies due and payable to Unigames shall be received by the Treasurer who shall lodge them without undue delay in the Unigames Banking Account for the credit of Unigames.
     \item Any two Executive Office Bearers of Unigames shall be empowered to jointly sign cheques or forms of authority for the withdrawal of any money from the Unigames Banking Account.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Payments} \label{sec:payments}
-\begin{enumerate}
+\begin{myEnumerate}
     \item \label{item:consumables_budget}The Committee may define a weekly budget from which the Treasurer may authorise the purchasing of consumables. These payments are subject to review by Committee.
     \item \label{item:printing_payments} Any Committee member may make payments for printing on behalf of Unigames. These payments are subject to review by Committee.
     \item With exception of the consumable and printing payments(\cref{item:consumables_budget,item:printing_payments}), and the executive power of the President (\cref{item:pres_duties}): No payments shall be made on behalf or in the name of Unigames unless it has been authorized by the Committee.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Library} \label{sec:library}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The Library is Unigames' primary asset and as such:
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item Activities detrimental to the Library's contents or use are not permitted.
               \item It is one of the main duties of Unigames and the Committee to maintain the Library and expand it.
               \item A reasonable portion of Unigames' annual income should be expended on improving the library and attendant materials.
               \item The Library shall be available to all members, except as excluded by this Constitution and Unigames Regulations.
-          \end{enumerate}
-\end{enumerate}
+          \end{myEnumerate}
+\end{myEnumerate}
 
 
 \section{Exclusion} \label{sec:exclusion}
-\begin{enumerate}
+\begin{myEnumerate}
     \item An Excluded Person is any person who, by means of Suspension or Expulsion, is not permitted to interact with the Society. They may not:
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item Access the Society’s physical spaces or assets, including the clubroom and the library.
               \item Attend events run by or in collaboration with the Society.
               \item Engage with the Society’s digital spaces, including social media groups or chat rooms.
-          \end{enumerate}
+          \end{myEnumerate}
     \item The Committee, in consultation with the Guild and the University as appropriate, may by two thirds majority Suspend any person for a fixed period of time.
     \item The Committee, in consultation with the Guild and the University as appropriate, may by unanimous vote Expel any person for an indefinite period of time.
     \item In the event a person believes they should no longer be permitted to interact with the Society, they may submit notice of their voluntary Exclusion to the President.
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item A voluntary Exclusion shall take effect only once it has been ratified by the Committee.
-          \end{enumerate}
+          \end{myEnumerate}
     \item "An Excluded Person may send written notice of their appeal to the Guild Societies Council President to be directed to an appropriate body (i.e. the Guild Executive, the UWA Complaints Resolution Unit, etc) based on the nature of the appeal and the original cause for Exclusion.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Availability of Constitution} \label{sec:availability}
-\begin{enumerate}
+\begin{myEnumerate}
     \item The Committee shall make available, on member's request, copies of this Constitution.
-\end{enumerate}
+\end{myEnumerate}
 
 
 \section{Alteration of Constitution} \label{sec:alteration}
-\begin{enumerate}
+\begin{myEnumerate}
     \item To amend this Constitution, the following steps must be taken:
-          \begin{enumerate}
-              \item Any two financial members of Unigames may not less than seven days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.
+          \begin{myEnumerate}
+              \item Any two Ordinary Financial members of Unigames may not less than seven days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.
               \item The motion may then be considered by Unigames at its next General Meeting and amendments which are relevant to the subject matter thereof may be moved without notice.
               \item The motion or any amendment thereto shall be deemed adopted if it receives a two-thirds majority of the General Meeting.
               \item The motion as adopted with any amendments shall come into force upon receiving the approval of Societies Council.
-          \end{enumerate}
-\end{enumerate}
+          \end{myEnumerate}
+\end{myEnumerate}
 
 
 \section{Dissolution} \label{sec:dissolution}
-\begin{enumerate}
+\begin{myEnumerate}
     \item In the event of Unigames' disaffiliation to the Societies Council \emph{and} cessation of activity, resources of Unigames, including the Library, shall be given into the holding of the University Science Fiction and Fantasy Association (UniSFA).
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the University Science Fiction and Fantasy Association (UniSFA), comes into being, that these resources shall be passed onto them.
-          \end{enumerate}
+          \end{myEnumerate}
     \item In the event of the University Science Fiction and Fantasy Association (UniSFA), no longer existing at the time of Unigames' dissolution, resources of Unigames, including the Library, shall be given into the holding of the Societies Council of the Guild.
-          \begin{enumerate}
+          \begin{myEnumerate}
               \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the Societies Council of the Guild, comes into being, that these resources shall be passed on to them.
-          \end{enumerate}
-\end{enumerate}
+          \end{myEnumerate}
+\end{myEnumerate}
 
 
 \begin{appendices}
@@ -438,17 +455,18 @@
         \item Revisions Adopted by General Meeting on 10 September 2019
         \item Revisions Adopted by General Meeting on 23 October 2020
         \item Revisions Adopted by General Meeting on 26 February 2021
+        \item Revisions Adopted by General Meeting on 13 February 2023
     \end{itemize}
 
     \medskip{}
 
     \noindent As witnessed by:
     \begin{description}
-        \item[{President:}] Alistair Langton
-        \item[{Vice~President:}] Emerald Aindow
-        \item[{Treasurer:}] Jackie Shan
-        \item[{Secretary:}] Guinevere Sellner
-        \item[{Librarian:}] Vikrum Sithambaram
+        \item[{President:}] Emerald Aindow
+        \item[{Vice~President:}] Jackie Shan
+        \item[{Treasurer:}] Alex Bennett
+        \item[{Secretary:}] Ethan Gibson
+        \item[{Librarian:}] Connor Brennan
     \end{description}
 
 \end{appendices}


### PR DESCRIPTION
Amendments: as adopted by Ordinary General Meeting on 13 February 2023
**Constitutional amendment from Jackie Shan, seconded by Alistair Langton:**
Recreated from [the proposed amendments document:](https://docs.google.com/document/d/1WizlKboRqA-PjbKrHOQr_ZZl11JFs1xOUCJ3G44HjAM/edit?tab=t.0)
UWA Student Guild has recently made it be known that non-student members of clubs aren’t allowed without written permission for each one - as UWA clubs should be student-run and student-oriented. When non-student members have the ability to vote (the same right as student members hold), there is the hypothetical chance that non-students could form a majority at a general meeting and alter the club’s directions to be non-student instead. While this is an extreme scenario, Unigames should ensure their constitution follows the guidelines that the UWA Student Guild and SOC sets for us.
The below amendments do the following things:

- Further define financial members as being able to be “Ordinary Financial Members” or “Associate Financial Members”
- Replace most references of “financial membership” with “ordinary financial membership”
- Define Ordinary Financial Members as student members, with voting rights
- Define an Associate Financial Member as a non-student member, with no voting rights

Formatting: editing enumerate, allowing LaTeX to have deep enough sublists so point 5.3.1.5.1.1 displays properly