### PR TITLE
Approved Constitutional Amendments 20240301

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -157,7 +157,7 @@
         \end{myEnumerate}
     \item \label{item:exec_vacancy} If an Executive Office Bearer position is vacant outside of a General Meeting for any reason, the vacancy shall either:
         \begin{myEnumerate}
-            \item Be filled through appointment of an existing Committee Member by Committee, subject to review at the next General Meeting.
+            \item Be filled through appointment of an existing, consenting Committee Member by Committee, subject to review at the next General Meeting.
                 \begin{myEnumerate}
                     \item When reviewing, a simple majority vote of the General Meeting will confirm the appointment. If such a vote fails, the position must be immediately filled by election (as per \cref{sec:elections}).
                 \end{myEnumerate}
@@ -171,7 +171,7 @@
                 \end{myEnumerate}
             \item Or it may remain vacant and be filled by election (as per \cref{sec:elections}), at the next General Meeting, which must be held within the next 3 weeks.
         \end{myEnumerate}
-    \item The President may appoint their predecessor to the non-voting, advisory Committee position of Immediate Past President for the duration of their term.
+    \item The President may appoint their predecessor with their consent to the non-voting, advisory Committee position of Immediate Past President for the duration of their term.
 \end{myEnumerate}
 
 
@@ -457,17 +457,18 @@
         \item Revisions Adopted by General Meeting on 26 February 2021
         \item Revisions Adopted by General Meeting on 13 February 2023
         \item Revisions Adopted by General Meeting on 9 May 2023
+        \item Revisions Adopted by General Meeting on 1 March 2024
     \end{itemize}
 
     \medskip{}
 
     \noindent As witnessed by:
     \begin{description}
-        \item[{President:}] Jackie Shan
-        \item[{Vice~President:}] Ethan Gibson
-        \item[{Treasurer:}] Connor Brennan
-        \item[{Secretary:}] Joshua Annison
-        \item[{Librarian:}] David Giles
+        \item[{President:}] Joshua Annison
+        \item[{Vice~President:}] Connor Brennan
+        \item[{Treasurer:}] Jack Bariss
+        \item[{Secretary:}] Chris Leak
+        \item[{Librarian:}] Gen Allen
     \end{description}
 
 \end{appendices}


### PR DESCRIPTION
Amendments: as adopted by Annual General Meeting on 1 March 2024

**Constitutional amendment proposed by Jackie Shan and seconded by Joshua Annison:**
AGM Minutes: https://unigames.asn.au/blog/post/unigames-annual-general-meeting-01032024/

Addition of the word "consenting" for appointments of executive committee members / IPP.
Bringing wording of our constitution in line with our previous "consenting" appointment amendment

**Original:** 6.5.1) Be filled through appointment of an existing Committee Member by Committee, subject to review at the next General Meeting.
**Amendment:** 6.5.1) Be filled through appointment of an existing, consenting Committee Member by Committee, subject to review at the next General Meeting.

**Original:** 6.7) The President may appoint their predecessor to the non-voting, advisory Committee position of Immediate Past President for the duration of their term.
**Amendment:** 6.7) The President may appoint their predecessor with their consent to the non-voting, advisory Committee position of Immediate Past President for the duration of their term.