### PR TITLE
Approved Constitutional Amendments 20250228

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -458,17 +458,18 @@
         \item Revisions Adopted by General Meeting on 13 February 2023
         \item Revisions Adopted by General Meeting on 9 May 2023
         \item Revisions Adopted by General Meeting on 1 March 2024
+        \item Revisions Adopted by General Meeting on 28 February 2025
     \end{itemize}
 
     \medskip{}
 
     \noindent As witnessed by:
     \begin{description}
-        \item[{President:}] Joshua Annison
-        \item[{Vice~President:}] Connor Brennan
-        \item[{Treasurer:}] Jack Bariss
-        \item[{Secretary:}] Chris Leak
-        \item[{Librarian:}] Gen Allen
+        \item[{President:}] Connor Brennan
+        \item[{Vice~President:}] Gen Allen
+        \item[{Treasurer:}] Anna Bailey
+        \item[{Secretary:}] Nene Mars
+        \item[{Librarian:}] Jeremy Butson
     \end{description}
 
 \end{appendices}

--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -67,9 +67,9 @@
 \section{Major Obligations to the Guild} \label{sec:obligations}
 \begin{myEnumerate}
     \item Unigames shall comply with the rules of Guild and Societies Council, and all other provisions enrolled upon the Guild Statutes Book.
-          \begin{myEnumerate}
-              \item All Office Bearers shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item All Office Bearers shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
+        \end{myEnumerate}
     \item Such rules supersede the Regulations of Unigames, and this Constitution, if and where contradiction occurs.
 \end{myEnumerate}
 
@@ -77,22 +77,22 @@
 \section{Membership of Unigames} \label{sec:membership}
 \begin{myEnumerate}
     \item Unigames membership is targeted at, but not restricted to:
-          \begin{myEnumerate}
-              \item Students of the University
-              \item Members of the Guild
-              \item Past members of Unigames
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item Students of the University
+            \item Members of the Guild
+            \item Past members of Unigames
+        \end{myEnumerate}
     \item Membership
         \begin{myEnumerate}
             \item A Member is any person who is a Financial Member or an Honorary Life Member.
             \item The Committee may, by regulation, afford Members benefits that may not be extended to people who are not Members, such as discounts and library borrowing privileges.
-            \begin{myEnumerate}
-                \item The Committee may temporarily restrict any benefits afforded to a Member as per \cref{sec:duties}
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item The Committee may temporarily restrict any benefits afforded to a Member as per \cref{sec:duties}
+                \end{myEnumerate}
             \item All Members will be afforded the right to attend and speak at a General Meeting.
-              \begin{myEnumerate}
-                  \item The Committee may temporarily restrict this right afforded to a Member as per \cref{sec:duties} and the UWA Student Guild Standing Orders.
-              \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item The Committee may temporarily restrict this right afforded to a Member as per \cref{sec:duties} and the UWA Student Guild Standing Orders.
+                \end{myEnumerate}
         \end{myEnumerate}
     \item Financial Membership
         \begin{myEnumerate}
@@ -103,25 +103,25 @@
                     \item An Excluded Person, as defined in \cref{sec:exclusion}, is not eligible to be a Financial Member.
                     \item A person may terminate their financial membership by means of resignation upon written request to the Secretary or President.
                     \item Each financial membership shall be either Ordinary or Associate
-                    \begin{myEnumerate}
-                      \item An Ordinary Financial Member is any person who is a current UWA Student at the time of purchase.
-                      \begin{myEnumerate}
-                          \item Ordinary Financial Members shall have the right to participate in a General Meeting as defined in \cref{sec:general_meetings} and \cref{sec:elections}.
-                      \end{myEnumerate}
-                      \item An Associate Financial Member is any person who is not a current UWA Student at the time of purchase.
-                  \end{myEnumerate}
+                        \begin{myEnumerate}
+                            \item An Ordinary Financial Member is any person who is a current UWA Student at the time of purchase.
+                                \begin{myEnumerate}
+                                    \item Ordinary Financial Members shall have the right to participate in a General Meeting as defined in \cref{sec:general_meetings} and \cref{sec:elections}.
+                                \end{myEnumerate}
+                            \item An Associate Financial Member is any person who is not a current UWA Student at the time of purchase.
+                        \end{myEnumerate}
                 \end{myEnumerate}
         \end{myEnumerate}
     \item Honorary Life Membership
-          \begin{myEnumerate}
-              \item An Honorary Life Member is any eligible person who has received an honorary life membership which has not been terminated.
+        \begin{myEnumerate}
+            \item An Honorary Life Member is any eligible person who has received an honorary life membership which has not been terminated.
                 \begin{myEnumerate}
                     \item Honorary life membership may be conferred by a two-thirds majority of a General Meeting upon any eligible person who has performed outstanding service to Unigames.
                     \item In exceptional circumstances, an honorary life membership may be removed by a two-thirds majority of a General Meeting.
                     \item An honorary life member may resign their honorary life membership upon written request to the Secretary or President.
                     \item An Excluded Person, as defined in \cref{sec:exclusion}, is not eligible to be an Honorary Life Member.
                 \end{myEnumerate}
-          \end{myEnumerate}
+        \end{myEnumerate}
 \end{myEnumerate}
 
 
@@ -194,10 +194,10 @@
     \item Only Ordinary Financial Members may vote at General Meetings.
         \begin{myEnumerate}
             \item Ordinary Financial Members who have held membership for at least 42 days prior to the General Meeting may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
-            \begin{myEnumerate}
-                \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the meeting has been recorded.
-                \item The intent of the absentee votes must be clear and unambiguous to the Secretary or Officer.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the meeting has been recorded.
+                    \item The intent of the absentee votes must be clear and unambiguous to the Secretary or Officer.
+                \end{myEnumerate}
             \item Absentee votes do not count as attendees for purposes of meeting quorum.
             \item Voting by means of a proxy is not allowed.
         \end{myEnumerate}
@@ -211,9 +211,9 @@
     \item The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 Ordinary Financial Members.
         \begin{myEnumerate}
             \item Such a meeting shall be held no later than 15 business days immediately following receipt of such requisition.
-            \begin{myEnumerate}
-                \item If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so.
+                \end{myEnumerate}
             \item \label{item:sgm_priority} Any business set out in the requisition shall have priority over all other business.
         \end{myEnumerate}
 \end{myEnumerate}
@@ -225,23 +225,23 @@
     \item Nominations for a Committee position shall be opened two weeks prior to the General Meeting, or as soon as practicable once a position has become vacant.
     \item Nominations shall be closed during the General Meeting.
     \item The General Meeting shall appoint two Returning Officers to conduct the election.
-    \begin{myEnumerate}
-        \item To ensure impartiality, each Returning Officer:
         \begin{myEnumerate}
-            \item Must not have been a Committee Member within the last 6 months;
-            \item Must disclose any potential conflicts of interest prior to appointment; and
-            \item Must not participate in the election outside their duties as a Returning Officer.
+            \item To ensure impartiality, each Returning Officer:
+                \begin{myEnumerate}
+                    \item Must not have been a Committee Member within the last 6 months;
+                    \item Must disclose any potential conflicts of interest prior to appointment; and
+                    \item Must not participate in the election outside their duties as a Returning Officer.
+                \end{myEnumerate}
         \end{myEnumerate}
-    \end{myEnumerate}
     \item The election of the offices and Committee shall be conducted by approval voting, i.e. each member may vote for any number of candidates.
     \item Only Ordinary Financial Members may nominate candidates, vote, or be nominated.
         \begin{myEnumerate}
             \item Ordinary Financial Members who have held membership for at least 42 days prior to the election may submit absentee votes in writing to the Secretary or an Officer designated by the Committee
-            \begin{myEnumerate}
-                \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the General Meeting has been recorded.
-                \item All absentee votes shall be given to the Returning Officers upon their appointment.
-                \item Absentee votes must be submitted in a form consistent with approval voting, and must be clear and unambiguous to the Returning Officers.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item Absentee votes must be submitted at least one hour before the time appointed for the meeting, except where the Member’s attendance at the General Meeting has been recorded.
+                    \item All absentee votes shall be given to the Returning Officers upon their appointment.
+                    \item Absentee votes must be submitted in a form consistent with approval voting, and must be clear and unambiguous to the Returning Officers.
+                \end{myEnumerate}
             \item Voting by means of a proxy is not allowed.
         \end{myEnumerate}
 \end{myEnumerate}
@@ -253,83 +253,83 @@
         \begin{myEnumerate}
             \item To carry out the will of the Society.
             \item To create Regulations defining the rules and procedures of the Society.
-            \begin{myEnumerate}
-                \item No regulation may contradict the Constitution.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item No regulation may contradict the Constitution.
+                \end{myEnumerate}
             \item The Committee may, by Regulation, define roles to aid in the operations of the Society, such as supervision of the clubroom.
-            \begin{myEnumerate}
-                \item The Committee shall have the power to appoint and remove specific Members to any roles.
-                \item The Committee cannot delegate greater powers than held by any individual Committee Member.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item The Committee shall have the power to appoint and remove specific Members to any roles.
+                    \item The Committee cannot delegate greater powers than held by any individual Committee Member.
+                \end{myEnumerate}
             \item \label{item:disciplinary_action} To enforce the rules and regulations of the Society and take disciplinary action where appropriate and proportional, including:
-            \begin{myEnumerate}
-                \item Restriction of Member benefits such as disallowing library usage;
-                \item Restriction of access to the Society’s physical spaces such as the clubroom or events;
-                \item Restriction of access to the Society’s digital spaces, such as social media groups;
-                \item Reporting misconduct to the Guild or University;
-                \item Imposition of fines;
-                \item Suspension or Expulsion as defined in \cref{sec:exclusion}.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item Restriction of Member benefits such as disallowing library usage;
+                    \item Restriction of access to the Society’s physical spaces such as the clubroom or events;
+                    \item Restriction of access to the Society’s digital spaces, such as social media groups;
+                    \item Reporting misconduct to the Guild or University;
+                    \item Imposition of fines;
+                    \item Suspension or Expulsion as defined in \cref{sec:exclusion}.
+                \end{myEnumerate}
             \item Acquire and dispose of property; to dispose of money; to open banking accounts; and to enter into contracts.
-            \begin{myEnumerate}
-                \item The Committee shall not borrow money or incur debts or liabilities on behalf of or in the name of Unigames to a greater amount than five dollars for each and every existing financial member of the Society.
-            \end{myEnumerate}
-            \end{myEnumerate}
-        \item Each Committee Member shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
+                \begin{myEnumerate}
+                    \item The Committee shall not borrow money or incur debts or liabilities on behalf of or in the name of Unigames to a greater amount than five dollars for each and every existing financial member of the Society.
+                \end{myEnumerate}
+        \end{myEnumerate}
+    \item Each Committee Member shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
         \begin{myEnumerate}
             \item To act in the best interests of the Society.
             \item To enforce rules and regulations of the Society and take disciplinary action where appropriate as defined in \cref{item:disciplinary_action}.
-            \begin{myEnumerate}
-                \item Any action taken by a Committee Member may only endure until the next Committee Meeting, at which the Committee shall review any decision.
-            \end{myEnumerate}
+                \begin{myEnumerate}
+                    \item Any action taken by a Committee Member may only endure until the next Committee Meeting, at which the Committee shall review any decision.
+                \end{myEnumerate}
         \end{myEnumerate}
-        \item \label{item:pres_duties} The President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item To coordinate and supervise the work of the Committee
-                  \item To carry out the will of Unigames
-                  \item To chair Committee and General Meetings of Unigames
-                  \item When immediate action is required in any matter affecting the interests of the society:
-                        \begin{myEnumerate}
-                            \item To take such actions upon seeking the advice and agreement of another member of the Committee (preferably the Vice President).
-                            \item Any actions taken as such, shall be subject to review at the next Committee meeting.
-                        \end{myEnumerate}
-              \end{myEnumerate}
-        \item The Vice President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item Assisting the President wherever possible.
-                  \item Whenever the President is unavailable, to take on the duties and powers of the President as detailed in \cref{item:pres_duties}.
-              \end{myEnumerate}
-        \item The Treasurer shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item To keep proper books of account dealing with the property and finances of Unigames and to furnish the Committee with such information upon request.
-                  \item To arrange and be responsible for the handling of the petty cash.
-                  \item To prepare a financial statement detailing income and expenses during their term of office, for presentation at the Annual General Meeting.
-                  \item To produce and deliver all necessary books, vouchers and other documents to the persons appointed by the Guild for the purpose of conducting an audit, insofar as such persons require.
-                  \item To produce and deliver all necessary books, receipts and other documents to the persons appointed by the Guild for the purpose of obtaining grants, insofar as such persons require.
-              \end{myEnumerate}
-        \item The Secretary shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item To record and distribute all proceedings of Unigames in all meetings.
-                  \item To provide the Guild with information about Unigames, upon request.
-                  \item To keep record of all Society members, and their contact information.
-                  \item To keep record of any members granted special powers, rights, or responsibilities by Committee.
-                  \item To keep record of any Regulations passed by Committee.
-              \end{myEnumerate}
-        \item The Librarian shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item To maintain the library.
-                  \item To maintain the catalogue and the borrowers records.
-                  \item To research opportunities to expand the library, with respect to the desires of Society members.
-                  \item To enforce Regulations regarding the library.
-              \end{myEnumerate}
-        \item The Fresher Representative shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
-              \begin{myEnumerate}
-                  \item To look out for the needs, and rights of the Freshers.
-                  \item To be aware of, and acquainted with all Freshers of the Society, insofar as is possible.
-                  \item To be involved, insofar as is possible, in any Fresher targeted activity the Society may run.
-              \end{myEnumerate}
-        \item Should any Committee Member be temporarily unable to fulfill their duties, as defined above, another Committee Member may be appointed to temporarily take on some or all of their duties. (For example if the Secretary is uncontactable, another Committee Member may be appointed to call a Special General Meeting).
-    \end{myEnumerate}
+    \item \label{item:pres_duties} The President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item To coordinate and supervise the work of the Committee
+            \item To carry out the will of Unigames
+            \item To chair Committee and General Meetings of Unigames
+            \item When immediate action is required in any matter affecting the interests of the society:
+                \begin{myEnumerate}
+                    \item To take such actions upon seeking the advice and agreement of another member of the Committee (preferably the Vice President).
+                    \item Any actions taken as such, shall be subject to review at the next Committee meeting.
+                \end{myEnumerate}
+        \end{myEnumerate}
+    \item The Vice President shall have the following duties and powers, in addition to those elsewhere in the Constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item Assisting the President wherever possible.
+            \item Whenever the President is unavailable, to take on the duties and powers of the President as detailed in \cref{item:pres_duties}.
+        \end{myEnumerate}
+    \item The Treasurer shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item To keep proper books of account dealing with the property and finances of Unigames and to furnish the Committee with such information upon request.
+            \item To arrange and be responsible for the handling of the petty cash.
+            \item To prepare a financial statement detailing income and expenses during their term of office, for presentation at the Annual General Meeting.
+            \item To produce and deliver all necessary books, vouchers and other documents to the persons appointed by the Guild for the purpose of conducting an audit, insofar as such persons require.
+            \item To produce and deliver all necessary books, receipts and other documents to the persons appointed by the Guild for the purpose of obtaining grants, insofar as such persons require.
+        \end{myEnumerate}
+    \item The Secretary shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item To record and distribute all proceedings of Unigames in all meetings.
+            \item To provide the Guild with information about Unigames, upon request.
+            \item To keep record of all Society members, and their contact information.
+            \item To keep record of any members granted special powers, rights, or responsibilities by Committee.
+            \item To keep record of any Regulations passed by Committee.
+        \end{myEnumerate}
+    \item The Librarian shall have the following duties, in addition to those elsewhere in the Constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item To maintain the library.
+            \item To maintain the catalogue and the borrowers records.
+            \item To research opportunities to expand the library, with respect to the desires of Society members.
+            \item To enforce Regulations regarding the library.
+        \end{myEnumerate}
+    \item The Fresher Representative shall have the following duties, in addition to those elsewhere in the constitution and in any Regulations:
+        \begin{myEnumerate}
+            \item To look out for the needs, and rights of the Freshers.
+            \item To be aware of, and acquainted with all Freshers of the Society, insofar as is possible.
+            \item To be involved, insofar as is possible, in any Fresher targeted activity the Society may run.
+        \end{myEnumerate}
+    \item Should any Committee Member be temporarily unable to fulfill their duties, as defined above, another Committee Member may be appointed to temporarily take on some or all of their duties. (For example if the Secretary is uncontactable, another Committee Member may be appointed to call a Special General Meeting).
+\end{myEnumerate}
 
 
 \section{Committee Meetings} \label{sec:committee_meetings}
@@ -337,23 +337,23 @@
     \item The Committee shall meet at such times and places as the President, in consultation with the other Committee members, shall determine.
     \item The Committee shall only exercise its powers (as defined in this constitution or in Regulations) at a properly convened meeting of the Committee, except as elsewhere provided in the Constitution.
     \item The Committee may conduct business by electronic circular, in the case of:
-          \begin{myEnumerate}
-              \item urgent business;
-              \item business which because of its nature could not be set on the agenda;or
-              \item business which by procedural motion, the Committee decided not to deal with at a Committee Meeting.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item urgent business;
+            \item business which because of its nature could not be set on the agenda;or
+            \item business which by procedural motion, the Committee decided not to deal with at a Committee Meeting.
+        \end{myEnumerate}
     \item The Secretary or President shall cause all members of the Committee to receive three days notice of any such meeting including a list of the business to be discussed. This list may be expanded upon during the meeting.
-          \begin{myEnumerate}
-              \item A meeting may be called without this notice, if eight or more, eligible to vote, Committee members are present, at least four of whom are executive office bearers.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item A meeting may be called without this notice, if eight or more, eligible to vote, Committee members are present, at least four of whom are executive office bearers.
+        \end{myEnumerate}
     \item The Secretary shall forthwith call a Special Committee Meeting, upon receiving a written requisition from at least two Committee members.
-          \begin{myEnumerate}
-              \item Any such Special Meeting shall be held not later than seven days immediately following the receipt of such requisition.
-                    \begin{myEnumerate}
-                        \item If the Secretary fails to call the meeting within that time, anyone of the members signing the requisition may do so.
-                    \end{myEnumerate}
-              \item Any business set out in the requisition shall have priority over all other business
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item Any such Special Meeting shall be held not later than seven days immediately following the receipt of such requisition.
+                \begin{myEnumerate}
+                    \item If the Secretary fails to call the meeting within that time, anyone of the members signing the requisition may do so.
+                \end{myEnumerate}
+            \item Any business set out in the requisition shall have priority over all other business
+        \end{myEnumerate}
     \item The quorum of a Committee meeting shall be six Committee members, who are eligible to vote, of which at least three must be executive office bearers.
     \item All meetings of the Committee shall be conducted in accordance with the procedures in the UWA Student Guild Standing Orders in all cases where they are applicable and not inconsistent with this Constitution or Regulations.
 \end{myEnumerate}
@@ -377,29 +377,29 @@
 \section{Library} \label{sec:library}
 \begin{myEnumerate}
     \item The Library is Unigames' primary asset and as such:
-          \begin{myEnumerate}
-              \item Activities detrimental to the Library's contents or use are not permitted.
-              \item It is one of the main duties of Unigames and the Committee to maintain the Library and expand it.
-              \item A reasonable portion of Unigames' annual income should be expended on improving the library and attendant materials.
-              \item The Library shall be available to all members, except as excluded by this Constitution and Unigames Regulations.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item Activities detrimental to the Library's contents or use are not permitted.
+            \item It is one of the main duties of Unigames and the Committee to maintain the Library and expand it.
+            \item A reasonable portion of Unigames' annual income should be expended on improving the library and attendant materials.
+            \item The Library shall be available to all members, except as excluded by this Constitution and Unigames Regulations.
+        \end{myEnumerate}
 \end{myEnumerate}
 
 
 \section{Exclusion} \label{sec:exclusion}
 \begin{myEnumerate}
     \item An Excluded Person is any person who, by means of Suspension or Expulsion, is not permitted to interact with the Society. They may not:
-          \begin{myEnumerate}
-              \item Access the Society’s physical spaces or assets, including the clubroom and the library.
-              \item Attend events run by or in collaboration with the Society.
-              \item Engage with the Society’s digital spaces, including social media groups or chat rooms.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item Access the Society’s physical spaces or assets, including the clubroom and the library.
+            \item Attend events run by or in collaboration with the Society.
+            \item Engage with the Society’s digital spaces, including social media groups or chat rooms.
+        \end{myEnumerate}
     \item The Committee, in consultation with the Guild and the University as appropriate, may by two thirds majority Suspend any person for a fixed period of time.
     \item The Committee, in consultation with the Guild and the University as appropriate, may by unanimous vote Expel any person for an indefinite period of time.
     \item In the event a person believes they should no longer be permitted to interact with the Society, they may submit notice of their voluntary Exclusion to the President.
-          \begin{myEnumerate}
-              \item A voluntary Exclusion shall take effect only once it has been ratified by the Committee.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item A voluntary Exclusion shall take effect only once it has been ratified by the Committee.
+        \end{myEnumerate}
     \item "An Excluded Person may send written notice of their appeal to the Guild Societies Council President to be directed to an appropriate body (i.e. the Guild Executive, the UWA Complaints Resolution Unit, etc) based on the nature of the appeal and the original cause for Exclusion.
 \end{myEnumerate}
 
@@ -413,25 +413,25 @@
 \section{Alteration of Constitution} \label{sec:alteration}
 \begin{myEnumerate}
     \item To amend this Constitution, the following steps must be taken:
-          \begin{myEnumerate}
-              \item Any two Ordinary Financial members of Unigames may not less than seven days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.
-              \item The motion may then be considered by Unigames at its next General Meeting and amendments which are relevant to the subject matter thereof may be moved without notice.
-              \item The motion or any amendment thereto shall be deemed adopted if it receives a two-thirds majority of the General Meeting.
-              \item The motion as adopted with any amendments shall come into force upon receiving the approval of Societies Council.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item Any two Ordinary Financial members of Unigames may not less than seven days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.
+            \item The motion may then be considered by Unigames at its next General Meeting and amendments which are relevant to the subject matter thereof may be moved without notice.
+            \item The motion or any amendment thereto shall be deemed adopted if it receives a two-thirds majority of the General Meeting.
+            \item The motion as adopted with any amendments shall come into force upon receiving the approval of Societies Council.
+        \end{myEnumerate}
 \end{myEnumerate}
 
 
 \section{Dissolution} \label{sec:dissolution}
 \begin{myEnumerate}
     \item In the event of Unigames' disaffiliation to the Societies Council \emph{and} cessation of activity, resources of Unigames, including the Library, shall be given into the holding of the University Science Fiction and Fantasy Association (UniSFA).
-          \begin{myEnumerate}
-              \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the University Science Fiction and Fantasy Association (UniSFA), comes into being, that these resources shall be passed onto them.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the University Science Fiction and Fantasy Association (UniSFA), comes into being, that these resources shall be passed onto them.
+        \end{myEnumerate}
     \item In the event of the University Science Fiction and Fantasy Association (UniSFA), no longer existing at the time of Unigames' dissolution, resources of Unigames, including the Library, shall be given into the holding of the Societies Council of the Guild.
-          \begin{myEnumerate}
-              \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the Societies Council of the Guild, comes into being, that these resources shall be passed on to them.
-          \end{myEnumerate}
+        \begin{myEnumerate}
+            \item This is given with the understanding that upon the formation of a club of similar spirit and objectives (see \cref{sec:objectives}) to Unigames, as judged by the Societies Council of the Guild, comes into being, that these resources shall be passed on to them.
+        \end{myEnumerate}
 \end{myEnumerate}
 
 


### PR DESCRIPTION
Formatting: fixing indentation within the code
Amendments: as adopted by Annual General Meeting on 28 February 2025
**Constitutional amendment proposed by Jackie Shan, seconded by Alistair Langton:**

Original: 15.1.1) Any two Ordinary Financial Members of Unigames may not less than four days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.
Amendment: 15.1.1) Any two Ordinary Financial Members of Unigames may not less than seven days before the day appointed for the next General Meeting submit to the Secretary a notice of motion by them proposing an alteration to the Constitution.

In 2020, we made several QOL changes for secretary with regards to notice required for motions to be sent to them, and notice required for them to put out announcements. Later on, when viewing our constitution on our website and the guild page, it seemed that we had forgotten to include the change for constitutional amendment motion notice to match the notice required for regular motions. Thus, this amendment was submitted to bring all notice requirements in line, as desired originally.
Upon further investigation (~July 2025), when updating the Constitution present on the Github, it was found that this had been been proposed as a constitutional amendment at the 2020 OGM, that had passed - but hadn't made it onto our website version. In future Constitutional updates, our website was used as the reference for new PDFs (to be sent to Guild), thus resulting in believing that we had initially forgotten it. Oops!