### PR TITLE
Remove setlistdepth

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -10,7 +10,6 @@
 \usepackage[utf8]{inputenc}
 
 % All items are numbered in dotted-decimal, starting with section number
-\setlistdepth{9}
 \newlist{myEnumerate}{enumerate}{9}
 \setlist[myEnumerate]{label*=.\arabic*}
 \setlist[myEnumerate,1]{label=\thesection.\arabic*}


### PR DESCRIPTION
`/setlistdepth` is not necessary, and throws errors when I try and compile the document. Removed it.