### PR TITLE
Approved Constitutional Amendments 20260227

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -375,6 +375,9 @@
 \begin{myEnumerate}
     \item All monies due and payable to Unigames shall be received by the Treasurer who shall lodge them without undue delay in the appropriate Unigames Banking Account for the credit of Unigames.
     \item Any two Executive Office Bearers of Unigames shall be empowered to jointly sign cheques or forms of authority for the withdrawal of any money from a Unigames Banking Account.
+        \begin{myEnumerate}
+            \item This requirement may be waived for the purposes of using a debit card related to a Unigames Banking Account for a specified budgeted purchase by a simple majority vote of the Committee.
+        \end{myEnumerate}
 \end{myEnumerate}
 
 
@@ -478,17 +481,18 @@
         \item Revisions Adopted by General Meeting on 1 March 2024
         \item Revisions Adopted by General Meeting on 28 February 2025
         \item Revisions Adopted by General Meeting on 22 September 2025
+        \item Revisions Adopted by General Meeting on 27 February 2026
     \end{itemize}
 
     \medskip{}
 
     \noindent As witnessed by:
     \begin{description}
-        \item[{President:}] Connor Brennan
-        \item[{Vice~President:}] Gen Allen
-        \item[{Treasurer:}] Anna Bailey
-        \item[{Secretary:}] Nene Mars
-        \item[{Librarian:}] Jeremy Butson
+        \item[{President:}] Anna Bailey
+        \item[{Vice~President:}] Ella Dillon
+        \item[{Treasurer:}] Jeremy Butson
+        \item[{Secretary:}] Lucy Auckland
+        \item[{Librarian:}] Sven Skead
     \end{description}
 
 \end{appendices}


### PR DESCRIPTION
Amendments: as adopted by Annual General Meeting on 27 February 2026
**Constitutional amendment proposed by Anna Bailey and seconded by Jeremy Butson:**
AGM Minutes: https://unigames.asn.au/blog/post/unigames-annual-general-meeting-27022026/
Proposal: https://docs.google.com/document/d/1paQeyWwHWn7bT7LD5SRGA_UMgmGcIDb2EbLNVosMypA

Addition of: 11.2.1) This requirement may be waived for the purposes of using a debit card related to a Unigames Banking Account for a specified budgeted purchase by a simple majority vote of the Committee.

Allowing withdrawal from Unigames Banking Accounts to be approved by simple majority vote rather than two signatories (by voting to waive the signatory requirement), in order to allow for a linked debit card to be used - removing the middle man (committee member that pays the upfront cost and needs to wait for reimbursement).