### PR TITLE
Fix Secretary last name

### DIFF
--- a/unigames_constitution.tex
+++ b/unigames_constitution.tex
@@ -491,7 +491,7 @@
         \item[{President:}] Anna Bailey
         \item[{Vice~President:}] Ella Dillon
         \item[{Treasurer:}] Jeremy Butson
-        \item[{Secretary:}] Lucy Auckland
+        \item[{Secretary:}] Lucy Auckland-Bevilacqua
         \item[{Librarian:}] Sven Skead
     \end{description}
 


### PR DESCRIPTION
Lucy's last name corrected from Auckland -> Auckland-Bevilacqua, as per request